### PR TITLE
Make values an internal attribute, make it required, add coordinate a…

### DIFF
--- a/test/test_parmed_namd.py
+++ b/test/test_parmed_namd.py
@@ -10,6 +10,7 @@ import parmed.namd as namd
 class TestNamdBin(unittest.TestCase):
     """Test the NamdBinCoor class."""
     def testRead(self):
+        """ Test reading NamdBinCoor file """
         coor = namd.NamdBinCoor.read(get_fn('ala_ala_ala.coor'))
         self.assertEqual(coor.natom,33)
 


### PR DESCRIPTION
…nd velocity

setters, make sure velocities are always read in in angstroms/picosecond
(appropriately scaling if necessary).

Make these classes more consistent with the rest of the ParmEd API.
